### PR TITLE
INT-2985: Upgrade to the new waluigi version to use containers when running builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-@Library('waluigi@v6.0.0-rc') _
+@Library('waluigi@v6.0.0') _
 
 beehiveFlowBuild(
   customSteps: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,47 +1,17 @@
 #!groovy
-@Library('waluigi@v4.1.0') _
+@Library('waluigi@v6.0.0-rc') _
 
-standardProperties()
-
-node("primary") {
-  echo "Clean workspace"
-  cleanWs()
-
-  stage("checkout") {
-    checkout localBranch(scm)
-  }
-
-  stage("dependencies") {
-    yarnInstall()
-  }
-
-  stage("stamp") {
-    sh "yarn beehive-flow stamp"
-  }
-
-  stage("build") {
-    sh "yarn build"
-  }
-
-  stage("lint") {
-    sh "yarn lint"
-  }
-
-  stage("storybook") {
-    def status = beehiveFlowStatus();
-    if (status.branchState == 'releaseReady' && status.isLatest) {
-      sshagent (credentials: ['jenkins2-github']) {
-        sh 'yarn deploy-storybook'
+beehiveFlowBuild(
+  customSteps: {
+    stage("update storybook") {
+      def status = beehiveFlowStatus()
+      if (status.branchState == 'releaseReady' && status.isLatest) {
+        tinyGit.withGitHubSSHCredentials {
+          exec('yarn deploy-storybook')
+        }
+      } else {
+        echo "Skipping as is not latest release"
       }
-    } else {
-      echo "Skipping as is not latest release"
     }
   }
-
-  stage("publish") {
-    sshagent(credentials: ['jenkins2-github']) {
-      sh "yarn beehive-flow publish"
-      sh "yarn beehive-flow advance-ci"
-    }
-  }
-}
+)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev": "rollup -c -w",
     "validate": "svelte-check",
     "lint": "eslint src/main/**/*.{ts,svelte}",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo 'No tests hooked up yet'",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "deploy-storybook": "yarn storybook-to-ghpages --source-branch=main",


### PR DESCRIPTION
Note: Similar to react I didn't add the container configuration here like we did in angular because when observing the memory usage of storybook for react it maxed out at ~550MB which should be okay. I also changed the `test` script so it didn't return an error exit code so it won't block the build.