### PR TITLE
Added missing export condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "svelte": "dist/index.js",
   "exports": {
     ".": {
+      "types": "./dist/ts/index.d.ts",
       "svelte": "./dist/index.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
   "main": "dist/index.umd.js",
   "module": "dist/index.mjs",
   "svelte": "dist/index.js",
+  "exports": {
+    ".": {
+      "svelte": "./dist/index.js"
+    }
+  },
   "types": "dist/ts/index.d.ts",
   "scripts": {
     "prebuild": "rm -rf ./dist",


### PR DESCRIPTION
With latest versions of Svelte, this became necessary. More info here: https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition

The fix is super simple, simply add the `export` field to `package.json` and Svelte/Vite will not throw any warnings (errors in the future). 

This is also backwards compatible and does not break any older versions.