### PR TITLE
INT-3320: Remove Quick Start guide from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,47 +10,6 @@ This package is a thin wrapper around [TinyMCE](https://github.com/tinymce/tinym
 * For the TinyMCE Svelte Technical Reference, see: [TinyMCE Documentation - TinyMCE Svelte Technical Reference](https://www.tiny.cloud/docs/tinymce/7/svelte-ref/).
 * For our quick demos, check out the TinyMCE Svelte [Storybook](https://tinymce.github.io/tinymce-svelte/).
 
-## Quick start
-
-### Create a Svelte App with Vite
-
-```bash
-npm create vite@5 tinymce-svelte-demo -- --template svelte
-cd tinymce-svelte-demo
-npm install
-```
-
-### Add the Editor component
-
-```bash
-npm install @tinymce/tinymce-svelte
-```
-
-### Import the TinyMCE component
-
-Replace the contents of `src/App.svelte` with the following code and replace `your-api-key` with your Tiny Cloud API key:
-
-```html
-<script>
-import Editor from '@tinymce/tinymce-svelte';
-let conf = {
-  menubar: false
-}
-</script>
-<main>
-  <h1>Hello Tiny</h1>
-  <Editor
-    apiKey="your-api-key"
-    {conf}
-  />
-</main>
-```
-
-### Run the app
-
-```bash
-npm run dev
-```
 
 ### Issues
 

--- a/README.md
+++ b/README.md
@@ -10,39 +10,47 @@ This package is a thin wrapper around [TinyMCE](https://github.com/tinymce/tinym
 * For the TinyMCE Svelte Technical Reference, see: [TinyMCE Documentation - TinyMCE Svelte Technical Reference](https://www.tiny.cloud/docs/tinymce/7/svelte-ref/).
 * For our quick demos, check out the TinyMCE Svelte [Storybook](https://tinymce.github.io/tinymce-svelte/).
 
-
 ## Quick start
 
-### Create a Svelte App from a template
+### Create a Svelte App with Vite
 
-```
-npx degit sveltejs/template my-tiny-app
-cd my-tiny-app
+```bash
+npm create vite@5 tinymce-svelte-demo -- --template svelte-ts
+cd tinymce-svelte-demo
+npm install
 ```
 
 ### Add the Editor component
 
-Install the editor component in your project
-
-```
+```bash
 npm install @tinymce/tinymce-svelte
 ```
 
-## Import the TinyMCE component
+### Import the TinyMCE component
 
-Import the TinyMCE component inside the script tag of your Svelte app
+Replace the contents of `src/App.svelte` with the following code and replace `your-api-key` with your Tiny Cloud API key:
 
-```
+```html
 <script lang="ts">
 import Editor from '@tinymce/tinymce-svelte';
+let conf = {
+  menubar: false
+}
 </script>
 <main>
-  <h1> Hello Tiny</h1>
-  <Editor />
+  <h1>Hello Tiny</h1>
+  <Editor
+    apiKey="your-api-key"
+    {conf}
+  />
 </main>
-
 ```
 
+### Run the app
+
+```bash
+npm run dev
+```
 
 ### Issues
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This package is a thin wrapper around [TinyMCE](https://github.com/tinymce/tinym
 ### Create a Svelte App with Vite
 
 ```bash
-npm create vite@5 tinymce-svelte-demo -- --template svelte-ts
+npm create vite@5 tinymce-svelte-demo -- --template svelte
 cd tinymce-svelte-demo
 npm install
 ```
@@ -31,7 +31,7 @@ npm install @tinymce/tinymce-svelte
 Replace the contents of `src/App.svelte` with the following code and replace `your-api-key` with your Tiny Cloud API key:
 
 ```html
-<script lang="ts">
+<script>
 import Editor from '@tinymce/tinymce-svelte';
 let conf = {
   menubar: false


### PR DESCRIPTION
Changes:
- Remove Quick Start guide from `README.md`

We want to direct users to [Tiny Docs](https://www.tiny.cloud/docs/tinymce/latest/svelte-cloud/) instead for the Quick Start guide. This way, there is only one source of information to update in the future.
The Quick Start guide docs page will be in https://github.com/tinymce/tinymce-docs/pull/3388 to use Vite v5.