### PR TITLE
INT-3324: Moved tinymce to be an optional peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Changed
-- Moved tinymce dependency to be a optional peer dependency. #INT-3324
+### Added
+- Added tinymce as an optional peer dependency. #INT-3324
 
 ## 3.0.0 - 2024-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added
-- Added tinymce as an optional peer dependency. #INT-3324
+### Fixed
+- tinymce "^v7.0.0 || ^v6.0.0 || ^v5.0.0" is now an optional peer dependency. #INT-3324
 
 ## 3.0.0 - 2024-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Moved tinymce dependency to be a optional peer dependency. #INT-3324
+
 ## 3.0.0 - 2024-06-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -45,6 +45,14 @@
     "CHANGELOG.md",
     "LICENSE.txt"
   ],
+  "peerDependencies": {
+    "tinymce": "^7.0.0 || ^6.0.0 || ^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "tinymce": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/core": "^7.14.8",
     "@rollup/plugin-commonjs": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/tinymce-svelte",
-  "version": "4.0.1-rc",
+  "version": "3.0.1-rc",
   "description": "TinyMCE Svelte Component",
   "private": false,
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "svelte-check": "^3.8.0",
     "svelte-loader": "^3.2.0",
     "svelte-preprocess": "^5.1.4",
-    "tinymce": "^7.1.1",
+    "tinymce": "^7.2.1",
     "tslib": "^2.6.2",
     "typescript": "^5.4.5",
     "vite": "^5.2.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinymce/tinymce-svelte",
-  "version": "3.0.1-rc",
+  "version": "4.0.1-rc",
   "description": "TinyMCE Svelte Component",
   "private": false,
   "publishConfig": {

--- a/src/main/component/Editor.svelte
+++ b/src/main/component/Editor.svelte
@@ -70,7 +70,7 @@
   export let apiKey: string = 'no-api-key';
   export let licenseKey: string | undefined = undefined;
   export let channel: Channel = '7';
-  export let scriptSrc: string = undefined;
+  export let scriptSrc: string | undefined = undefined;
   export let conf: EditorOptions = {};
   export let modelEvents: string = 'change input undo redo';
   export let value: string = '';
@@ -139,7 +139,7 @@
       },
     };
     element.style.visibility = '';
-    void getTinymce().init(finalInit);
+    void getTinymce()?.init(finalInit);
   };
   
   onMount(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7488,10 +7488,10 @@ tiny-invariant@^1.3.1, tiny-invariant@^1.3.3:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
 
-tinymce@^7.1.1:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-7.1.2.tgz#cb40e527dc03d6a0547a23c91231a946e50dae03"
-  integrity sha512-I/M5WRyEJjwIhyIv6FhkvZS1mWNbb0sIEvDkP8akBnuV1X78mkNhi6Kz9FBBbHzy61U3pmXgzyCSaDZfdQbCSg==
+tinymce@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-7.2.1.tgz#9b4f6b5a0fa647e2953c174ac69aa47483683332"
+  integrity sha512-ADd1cvdIuq6NWyii0ZOZRuu+9sHIdQfcRNWBcBps2K8vy7OjlRkX6iw7zz1WlL9kY4z4L1DvIP+xOrVX/46aHA==
 
 tmp@^0.2.1:
   version "0.2.3"


### PR DESCRIPTION
[INT-3324](https://ephocks.atlassian.net/browse/INT-3324)

Changes:
- The `tinymce` package is now an optional peer dependency.
- Imports of `tinymce` now use `import type ...` to help prevent accidental usage of tinymce JS code through a direct import in this way.
- Fixed two minor type errors in Editor.svelte

`tinymce` wasn't included as a dependency before, so this could fall into a patch version update.

[INT-3324]: https://ephocks.atlassian.net/browse/INT-3324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ