### PR TITLE
TINY-11909: Add support for readonly mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - tinymce "^v7.0.0 || ^v6.0.0 || ^v5.0.0" is now an optional peer dependency. #INT-3324
 
+### Changed
+- `disabled` property is now mapped to the TinyMCE `disabled` option.
+
+### Added
+- Added `readonly` property that maps to the TinyMCE `readonly` option.
+
 ## 3.0.0 - 2024-06-05
 
 ### Added

--- a/src/main/component/Editor.svelte
+++ b/src/main/component/Editor.svelte
@@ -67,6 +67,7 @@
   export let id: string = uuid('tinymce-svelte'); // default values
   export let inline: boolean | undefined = undefined;
   export let disabled: boolean = false;
+  export let readonly: boolean = false;
   export let apiKey: string = 'no-api-key';
   export let licenseKey: string | undefined = undefined;
   export let channel: Channel = '7';
@@ -82,6 +83,7 @@
   let editorRef: TinyMCEEditor | null;
   let lastVal = value;
   let disablindCache = disabled;
+  let readonlyCache = readonly;
   
   const dispatch = createEventDispatcher();
   
@@ -90,10 +92,14 @@
       editorRef.setContent(value);
       text = editorRef.getContent({format: 'text'});
     }
+    if (editorRef && readonly !== readonlyCache) {
+      readonlyCache = readonly;
+      editorRef.mode.set(readonly ? 'readonly' : 'design');
+    }
     if (editorRef && disabled !== disablindCache) {
       disablindCache = disabled;
       if (typeof editorRef.mode?.set === 'function') {
-        editorRef.mode.set(disabled ? 'readonly' : 'design');
+        editorRef.options.set('disabled', disabled);
       } else {
         interface TinyMCEEditor4 extends TinyMCEEditor {
           setMode: (input: string) => void
@@ -117,7 +123,8 @@
       ...conf,
       target: element,
       inline: inline !== undefined ? inline : conf.inline !== undefined ? conf.inline : false,
-      readonly: disabled,
+      readonly,
+      disabled,
       license_key: licenseKey,
       setup: (editor: TinyMCEEditor) => {
         editorRef = editor;

--- a/src/stories/Editor.stories.svelte
+++ b/src/stories/Editor.stories.svelte
@@ -6,8 +6,8 @@
 </script>
 
 <script>
-  import Editor from '../main/component/Editor.svelte';
   import { Story } from '@storybook/addon-svelte-csf';
+  import Editor from '../main/component/Editor.svelte';
 
   const apiKey = 'b1g4d59rwwqxx1vj7mci23rjj8ubgb46i4xsio6ieig6fkps';
   const content = `
@@ -20,10 +20,14 @@ TinyMCE provides a <span style="text-decoration: underline;">full-featured</span
 
   let value = content;
   let disabled = true;
+  let readonly = true;
   let text = '';
 
   const toggleDisabled = () => {
     disabled = !disabled;
+  }
+  const toggleReadonly = () => {
+    readonly = !readonly;
   }
   const controls = { channel: '7', conf: { plugins: 'help' } }
 </script>
@@ -66,6 +70,7 @@ TinyMCE provides a <span style="text-decoration: underline;">full-featured</span
 <Story name="Disabling" args={controls} let:args>
   <div>
     <button on:click={toggleDisabled}>{#if disabled}Enable{:else}Disable{/if}</button>
-    <Editor {apiKey} {disabled} {value} {...args}/>
+    <button on:click={toggleReadonly}>{#if readonly}Not Readonly{:else}Readonly{/if}</button>
+    <Editor {apiKey} {disabled} {readonly} {value} {...args}/>
   </div>
 </Story>

--- a/src/stories/Editor.stories.svelte
+++ b/src/stories/Editor.stories.svelte
@@ -70,7 +70,13 @@ TinyMCE provides a <span style="text-decoration: underline;">full-featured</span
 <Story name="Disabling" args={controls} let:args>
   <div>
     <button on:click={toggleDisabled}>{#if disabled}Enable{:else}Disable{/if}</button>
+    <Editor {apiKey} {disabled} {value} {...args}/>
+  </div>
+</Story>
+
+<Story name="Readonly" args={controls} let:args>
+  <div>
     <button on:click={toggleReadonly}>{#if readonly}Not Readonly{:else}Readonly{/if}</button>
-    <Editor {apiKey} {disabled} {readonly} {value} {...args}/>
+    <Editor {apiKey} {readonly} {value} {...args}/>
   </div>
 </Story>


### PR DESCRIPTION
Related ticket: TINY-11909

added support for readonly mode and now disabled prop uses the editor disable