### PR TITLE
INT-3353: Update to use TinyMCE 8 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 This package is a thin wrapper around [TinyMCE](https://github.com/tinymce/tinymce) to make it easier to use in a Svelte application.
 
-* For the TinyMCE Svelte Quick Start, see: [TinyMCE Documentation - Svelte Integration](https://www.tiny.cloud/docs/tinymce/7/svelte-cloud/).
-* For a self-hosted setup using TinyMCE package with TinyMCE Svelte, see: [TinyMCE Documentation - TinyMCE package with Svelte](https://www.tiny.cloud/docs/tinymce/7/svelte-pm/).
-* For a self-hosted setup using TinyMCE .zip package with TinyMCE Svelte, see: [TinyMCE Documentation - TinyMCE .zip package with Svelte](https://www.tiny.cloud/docs/tinymce/7/svelte-zip/).
-* For the TinyMCE Svelte Technical Reference, see: [TinyMCE Documentation - TinyMCE Svelte Technical Reference](https://www.tiny.cloud/docs/tinymce/7/svelte-ref/).
+* For the TinyMCE Svelte Quick Start, see: [TinyMCE Documentation - Svelte Integration](https://www.tiny.cloud/docs/tinymce/latest/svelte-cloud/).
+* For a self-hosted setup using TinyMCE package with TinyMCE Svelte, see: [TinyMCE Documentation - TinyMCE package with Svelte](https://www.tiny.cloud/docs/tinymce/latest/svelte-pm/).
+* For a self-hosted setup using TinyMCE .zip package with TinyMCE Svelte, see: [TinyMCE Documentation - TinyMCE .zip package with Svelte](https://www.tiny.cloud/docs/tinymce/latest/svelte-zip/).
+* For the TinyMCE Svelte Technical Reference, see: [TinyMCE Documentation - TinyMCE Svelte Technical Reference](https://www.tiny.cloud/docs/tinymce/latest/svelte-ref/).
 * For our quick demos, check out the TinyMCE Svelte [Storybook](https://tinymce.github.io/tinymce-svelte/).
 
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "LICENSE.txt"
   ],
   "peerDependencies": {
-    "tinymce": "^7.0.0 || ^6.0.0 || ^5.0.0"
+    "tinymce": "^8.0.0 || ^7.0.0 || ^6.0.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "tinymce": {

--- a/src/main/component/Editor.svelte
+++ b/src/main/component/Editor.svelte
@@ -65,7 +65,7 @@
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
   import type { TinyMCE, Editor as TinyMCEEditor } from 'tinymce';
   type EditorOptions = Parameters<TinyMCE['init']>[0];
-  type Channel = `${'4' | '5' | '6' | '7'}${'' | '-dev' | '-testing' | `.${number}` | `.${number}.${number}`}`;
+  type Channel = `${'4' | '5' | '6' | '7' | '8'}${'' | '-dev' | '-testing' | `.${number}` | `.${number}.${number}`}`;
 
   import { bindHandlers } from './Utils';
   export let id: string = uuid('tinymce-svelte'); // default values
@@ -73,8 +73,8 @@
   export let disabled: boolean = false;
   export let readonly: boolean = false;
   export let apiKey: string = 'no-api-key';
-  export let licenseKey: string = 'glp';
-  export let channel: Channel = '7';
+  export let licenseKey: string = 'gpl';
+  export let channel: Channel = '8';
   export let scriptSrc: string | undefined = undefined;
   export let conf: EditorOptions = {};
   export let modelEvents: string = 'change input undo redo';

--- a/src/main/component/Editor.svelte
+++ b/src/main/component/Editor.svelte
@@ -73,7 +73,7 @@
   export let disabled: boolean = false;
   export let readonly: boolean = false;
   export let apiKey: string = 'no-api-key';
-  export let licenseKey: string | undefined = undefined;
+  export let licenseKey: string = 'glp';
   export let channel: Channel = '7';
   export let scriptSrc: string | undefined = undefined;
   export let conf: EditorOptions = {};

--- a/src/stories/Editor.stories.svelte
+++ b/src/stories/Editor.stories.svelte
@@ -29,7 +29,7 @@ TinyMCE provides a <span style="text-decoration: underline;">full-featured</span
   const toggleReadonly = () => {
     readonly = !readonly;
   }
-  const controls = { channel: '7', conf: { plugins: 'help' } }
+  const controls = { channel: '8' }
 </script>
 
 <Story name="Iframe" args={{ ...controls, inline: false }} let:args>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7488,9 +7488,9 @@ tiny-invariant@^1.3.1, tiny-invariant@^1.3.3:
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
 
 tinymce@^7.2.1:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-7.2.1.tgz#9b4f6b5a0fa647e2953c174ac69aa47483683332"
-  integrity sha512-ADd1cvdIuq6NWyii0ZOZRuu+9sHIdQfcRNWBcBps2K8vy7OjlRkX6iw7zz1WlL9kY4z4L1DvIP+xOrVX/46aHA==
+  version "7.9.1"
+  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-7.9.1.tgz#1b18bad9cb7a3b4b12e3e5a7f29fc7daad0713d7"
+  integrity sha512-zaOHwmiP1EqTeLRXAvVriDb00JYnfEjWGPdKEuac7MiZJ5aiDMZ4Unc98Gmajn+PBljOmO1GKV6G0KwWn3+k8A==
 
 tmp@^0.2.1:
   version "0.2.3"


### PR DESCRIPTION
Ticket: INT-3353

Description of changes:
- Added `8` to the allowed versions list
- Updated demo to use `8-dev` channel
- Defaulted `license_key` to `gpl`